### PR TITLE
Use valid category value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Max Chan <max@maxchan.info>
 maintainer=Max Chan <max@maxchan.info>
 sentence=Driver for Texas Instruments TLC5615 10-bit DAC
 paragraph=The TLC5615 is *the cheapest* percision DAC available on TI's website, available in a breadboard-friendly DIP-8 package, and it is fairly simple to use (and being a resistor string DAC it can double as a digipot with one terminal permanently grounded.) The current version of TLC5615 library requires the latest version of SPI library to work.
-category=Input/Output
+category=Signal Input/Output
 url=https://en.maxchan.info/arduino#tlc5615
 architectures=*


### PR DESCRIPTION
Using any category value not on the[ valid category list](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format) in the library specification causes a warning on every compile(whether or not this library is included in the program) in Arduino IDE 1.6.6 or greater:

```
WARNING: Category 'Input/Output' in library ArduMax TLC5615 Driver is not valid. Setting to 'Uncategorized'
```

I chose the category that seemed closest to the previous value but am happy to change it to any other valid category value and squash to a single commit.
